### PR TITLE
properly redirect www.reddit.com

### DIFF
--- a/teddit-redirect.js
+++ b/teddit-redirect.js
@@ -9,7 +9,7 @@ function onSettingsRead(item) {
   }
 
   const original_url = window.location.href
-  const new_url = original_url.replace('old.reddit.com', instance).replace('reddit.com', instance)
+  const new_url = original_url.replace('old.reddit.com', instance).replace(/(www\.)?reddit.com/, instance)
   window.location.replace(new_url)
 }
 


### PR DESCRIPTION
`reddit.com` seems to redirect to `www.reddit.com`, which makes the redirect break if the configured instance does not support the `www.` subdomain

This commit makes www.reddit.com also just redirect to `instance` instead of `www.instance`